### PR TITLE
feat: allow overriding the newrelic sdk version on Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
   // Buildscript is evaluated before everything else so we can't use getExtOrDefault
   def kotlin_version = rootProject.ext.has('kotlinVersion') ? rootProject.ext.get('kotlinVersion') : project.properties['Newrelic_kotlinVersion']
+  def newrelic_version = rootProject.ext.has('newrelicVersion') ? rootProject.ext.get('newrelicVersion') : project.properties['Newrelic_newrelicVersion']
 
   repositories {
     google()
@@ -11,7 +12,7 @@ buildscript {
     classpath 'com.android.tools.build:gradle:3.2.1'
     // noinspection DifferentKotlinGradleVersion
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    classpath "com.newrelic.agent.android:android-agent:6.+"
+    classpath "com.newrelic.agent.android:android-agent:$newrelic_version"
   }
 }
 
@@ -119,6 +120,7 @@ repositories {
 }
 
 def kotlin_version = getExtOrDefault('kotlinVersion')
+def newrelic_version = getExtOrDefault('newrelicVersion')
 
 dependencies {
   // noinspection GradleDynamicVersion
@@ -126,5 +128,5 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
   // newrelic agent
-  implementation "com.newrelic.agent.android:android-agent:6.+"
+  implementation "com.newrelic.agent.android:android-agent:$newrelic_version"
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,3 +2,4 @@ Newrelic_kotlinVersion=1.5.30
 Newrelic_compileSdkVersion=29
 Newrelic_buildToolsVersion=29.0.2
 Newrelic_targetSdkVersion=29
+Newrelic_newrelicVersion=6.+


### PR DESCRIPTION
The latest 6.x version seems to be given problems in certain environments. This PR extends the library to allow overriding the default newrelic version. By default, it will still select the `6.+` version making this PR fully backwards compatible.

To override it in your app, add the following config to your `android/build.gradle`

```
buildscript {
    ext {
        buildToolsVersion = "29.0.3"
        minSdkVersion = 21
        compileSdkVersion = 30
        targetSdkVersion = 30

        // Latest NewRelic android Agent fails with OkHttp. Revert to 6.1.0
        // https://github.com/newrelic-experimental/NewRelicReactNativeModule/issues/17#issuecomment-1011137629
        newrelicVersion = "6.1.0"
    }
    ...
}
```