### PR TITLE
Fix iOS imports for new react-native releases

### DIFF
--- a/ios/RNNewRelic.m
+++ b/ios/RNNewRelic.m
@@ -1,6 +1,6 @@
 #import "RNNewRelic.h"
-#import "RCTConvert.h"
-#import "RCTExceptionsManager.h"
+#import <React/RCTConvert.h>
+#import <React/RCTExceptionsManager.h>
 
 @implementation RNNewRelic
 


### PR DESCRIPTION
Fixes #6 

Hi! There have been build issues with this package using newer react-native versions. This PR fixes the imports to work on all versions of react-native by correctly scoping them.